### PR TITLE
setting up the Group views and templates(1/3)

### DIFF
--- a/social/groups/templates/groups/group_base.html
+++ b/social/groups/templates/groups/group_base.html
@@ -5,15 +5,15 @@
       <!-- these block tag wiil be used to inherit to all the other templates
           in the groups template folder, these different tag will be allow
           to layout the unique content distinct to the webpage -->
-      {% block pregroup%}
+      {% block pregroup %}
 
       {% endblock %}
 
-      {% block group_content%}
+      {% block group_content %}
 
       {% endblock %}
 
-      {% block postgroup%}
+      {% block postgroup %}
 
       {% endblock %}
 

--- a/social/groups/templates/groups/group_base.html
+++ b/social/groups/templates/groups/group_base.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+  <div class="container">
+    <div class="row">
+      <!-- these block tag wiil be used to inherit to all the other templates
+          in the groups template folder, these different tag will be allow
+          to layout the unique content distinct to the webpage -->
+      {% block pregroup%}
+
+      {% endblock %}
+
+      {% block group_content%}
+
+      {% endblock %}
+
+      {% block postgroup%}
+
+      {% endblock %}
+
+
+    </div>
+
+  </div>
+
+
+{%endblock%}

--- a/social/groups/templates/groups/group_detail.html
+++ b/social/groups/templates/groups/group_detail.html
@@ -1,0 +1,41 @@
+{% extends from 'group/group_base.html' %}
+
+{% block pregroup %}
+<!-- before the group show the current group information - linked and found in
+group model -  whoch is linked to the class based views -->
+<h1>{{group.name}}</h1>
+<h2>member count: {{group.members.count}}</h2>
+<!-- give option to leave or join the group button, if the user is a loged in
+and if the user is a member or not -->
+
+<div class="content">
+  {% if user in group.members.all %}
+  <!-- if the user in the group's member list(attribute of group model) -->
+  <a href="{%url 'groups:leave' slug=group.slug %}"
+  class='btn btn-lg btn-fill btn-warning'>Leave Group</a>
+  <!-- page not done however, will be done in the urls.py -->
+  {% else %}
+  <a href="{%url 'groups:join' slug=group.slug %}"
+  class='btn btn-lg btn-fill btn-primary'>Join Group</a>
+  <!-- page not done however, will be done in the urls.py -->
+</div>
+{% endblock %}
+
+{% block group_content %}
+<div class="col-md-8">
+  {% if group.post.count == 0 %}
+   <!--checks if the current froup contains post
+ if there is NO post then show message -->
+   <h2>No Post in this group yet</h2>
+   {%else %}
+   <!-- if there is a post, cycle through all the post linked with the current gorup
+ and list them out -->
+   {% for p in group.posts %}
+    {% include "posts/_post.html" %}
+    <!-- while listing the post, per post being iterated the template call -include,
+     injects very common post html code. enabling to practice DRY principle-->
+   {% endfor %}
+
+
+  {% endif %}
+</div>

--- a/social/groups/templates/groups/group_detail.html
+++ b/social/groups/templates/groups/group_detail.html
@@ -35,7 +35,5 @@ and if the user is a member or not -->
     <!-- while listing the post, per post being iterated the template call -include,
      injects very common post html code. enabling to practice DRY principle-->
    {% endfor %}
-
-
   {% endif %}
 </div>

--- a/social/groups/templates/groups/group_form.html
+++ b/social/groups/templates/groups/group_form.html
@@ -1,0 +1,13 @@
+{% extends 'group/group_base.html' %}
+{% load bootstrap3 %}
+<!-- its a form so we load bootstrap to aid the development -->
+{%block group_content %}
+  <h4>create form</h4>
+  <form action="{url 'group:create'}" method="POST" id='groupForm'>
+    <!-- once user submit send to create page -->
+    {% csrf_token %}
+    {% bootstrap_form form %}
+    <!-- inject the form (which is connected from the CreateView)-->
+    <input type="submit" class="btn btn-primary btn-large" value="Create">
+  </form>
+{% endblock %}

--- a/social/groups/templates/groups/group_list.html
+++ b/social/groups/templates/groups/group_list.html
@@ -1,0 +1,58 @@
+{% extends "groups/group_base.html" %}
+{% block pregroup %}
+  <div class="col-md-4">
+    <div class="content">
+      <!-- if the user logged in and authenticated
+      show a message saying welcome back with a link to the user's
+      profile(containing all thier post), display the current users username-->
+      {% if user.is_authenticated %}
+      <h2>Welcome back!</h2>
+      <a href="{%url 'posts:for_user' username=user.username %}">
+        @{{user.username}}
+      </a>
+      <!-- if not  -->
+      {% endif %}
+      <h2>Groups</h2>
+      <p>Welcome to the Groups page! </p>
+    </div>
+    <!-- if the user is authenticated, give option to create a new group -->
+    {% user.is_authenticated %}
+      <a href="{%url 'group:create'%}" class='btn btn=md btn-fil btn-warning'>
+        Create new Group
+      </a>
+    {%endif%}
+  </div>
+{% endblock %}
+
+{% block group_content %}
+<div class="col-md-8">
+  <div class="lsit-group">
+    {% for group in object_list %}
+    <!-- object list - this is the list of groups object within group.html   -->
+    <a class ='list-group-item' href="{%url 'group:single' slug=group.slug %}">
+      <h3 class='title list-group-item-heading'>{{group.name}}</h3>
+        <!-- have an ancher tag to link to the group name through the slug connection -->
+        <div class="list-group-item container-fluid">
+          {{group.description|safe}}
+          <!-- get the description attribute of the group model and '|safe',
+          allows the use of html code in safe way e.g if something is bold, you
+          see the format instead of seeing the tag -->
+          <div class="row">
+            <!-- the follwoing themeplate tag, is the method of
+              showing how many member and post each group object has in the
+              list of groups -->
+            <div class="col-md-4">
+              <span class ='badge'>{{group.members.count}}</span>
+              member{{group.members.count|pluralized}}
+            </div>
+            <div class="col-md-4">
+              <span class='badge'>{{group.post.count}}</span>
+              post{{group.post.count|pluralized}}
+            </div>
+          </div>
+        </div>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/social/groups/views.py
+++ b/social/groups/views.py
@@ -1,3 +1,23 @@
 from django.shortcuts import render
-
+from django.contrib.auth.mixins import (LoginRequiredMixin,
+                                        PermissionRequiredMixin)
+from django.urls import reverse
+from django.views import generic
+from .models import Group, groupMember
 # Create your views here.
+
+class CreateGroup(LoginRequiredMixin, generic.CreateView)
+# The view that allows the user to create a forum.
+    fields('name', 'description')
+    # the fields from the model we want to the user to edit
+    model = Group
+    # DB connection with group DB/Model
+    #NOTE STILL NEED TO CONNECT TO TEMPLATE
+
+class SingleGroup(generic.DetailView):
+# the view to see all the post in a group
+    model = Group
+
+class ListGroup(generic.ListView):
+# the View that allows the user to see ALL the available form look into
+    model = Group


### PR DESCRIPTION
within this push

the views for the pages in the  groups webapp is created with class based views.  These are: createGroup(to create a group), SingleGroup(list of post within a group) and ListGroup(List of all created Views).

Group templates.

1. The group_base.html, i had it extend from the base.html found in the project folder, then further inputted a conted block. however, this content block is much different - this blovk content cotains different keywords that allows to distribute unique code distinct to the webpage, and will be refernced to determine where the certain code should be. this will be displayed further in the all templates within groups.

2. Group_detail Template, this templates displays the use of the different content block being used. within the first content block a title injection and injection of the total members within a group. A check was also inputted in the first content block to give the user the option join or leave.

The the next content block - group_conent.  simply display all the post within the current group. if there isnt a post within the group then it will send an a message that there is no current post with in it. another unique thing added here is the include template tag. there is another  code injection allows the concept of DRY coding